### PR TITLE
Fix issues with stopping radio on Mac + Support Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       method_source (>= 0.8.2, < 1.1.0)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-darwin-19
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 **[cvlc](https://github.com/videolan/vlc)**
 
+On Windows, you also have to add the installed VLC app directory to the PATH environment (e.g. `C:\Program Files (x86)\VideoLAN\VLC`)
+
 ### Ruby Gem:
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,25 +11,6 @@
 
 **[cvlc](https://github.com/videolan/vlc)**
 
-Note that on the Mac, you do not get `cvlc` by default when installing [VLC](https://www.videolan.org/vlc/download-macosx.html), so you also have to do the following:
-
-1- Create a `~/bin/cvlc` file with the following content:
-```sh
-#!/bin/sh
-
-/Applications/VLC.app/Contents/MacOS/VLC -I rc $@
-```
-
-2- Run:
-```
-chmod +x ~/bin/cvlc
-```
-
-3- Add the following line to `~/.zprofile`, `~/.zshrc`, `~/.bash_profile`, `~/.profile`, or `~/.bashrc` depending on your system setup:
-```sh
-export PATH="$PATH:$HOME/bin"
-```
-
 ### Ruby Gem:
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@
 
 ### Requirements:
 
-**[cvlc](https://github.com/videolan/vlc)**
+**[VLC](https://github.com/videolan/vlc)**
 
-On Windows, you also have to add the installed VLC app directory to the PATH environment (e.g. `C:\Program Files (x86)\VideoLAN\VLC`)
+`rubio` uses the `cvlc` command on Linux and `vlc -I rc` on Mac and Windows as the audio playback backend.
+
+On Mac, it is recommended that you install VLC via [Homebrew](https://brew.sh/) to ensure the `vlc` command is added to the PATH environment variable automatically:
+
+```
+brew install vlc
+```
+
+On Windows, install VLC using the [Windows installer](https://www.videolan.org/vlc/download-windows.html), and then add the installed VLC app directory to the PATH environment variable (e.g. `C:\Program Files (x86)\VideoLAN\VLC`) to make the `vlc` command available.
 
 ### Ruby Gem:
 
@@ -25,7 +33,7 @@ gem install rubio-radio
 rubio
 ```
 
-Default player is `cvlc`. But you can use any command line player that can take URL of radio station as its first argument.
+Default player is `cvlc` on Linux and `vlc -I rc` on Mac and Windows. But, you can use any command line player that can take URL of radio station as its first argument.
 
 ```
 rubio --backend mpg123

--- a/exe/rubio
+++ b/exe/rubio
@@ -4,10 +4,10 @@
 require 'rubio'
 
 require 'optparse'
-backend = 'cvlc'
+backend = OS.mac? ? 'vlc -I rc' : 'cvlc'
 debug = false
 opt = OptionParser.new
-opt.on('--vlc') { backend = 'cvlc' }
+opt.on('--vlc') { backend = OS.mac? ? 'vlc -I rc' : 'cvlc' }
 opt.on('--mpg123') { backend = 'mpg123' }
 opt.on('--backend CMD') { |b| backend = b }
 opt.on('--debug') { debug = true }

--- a/exe/rubio
+++ b/exe/rubio
@@ -4,10 +4,10 @@
 require 'rubio'
 
 require 'optparse'
-backend = OS.mac? ? 'vlc -I rc' : 'cvlc'
+backend = OS.linux? ? 'cvlc' : 'vlc -I rc'
 debug = false
 opt = OptionParser.new
-opt.on('--vlc') { backend = OS.mac? ? 'vlc -I rc' : 'cvlc' }
+opt.on('--vlc') { backend = OS.linux? ? 'cvlc' : 'vlc -I rc' }
 opt.on('--mpg123') { backend = 'mpg123' }
 opt.on('--backend CMD') { |b| backend = b }
 opt.on('--debug') { debug = true }

--- a/lib/rubio/player.rb
+++ b/lib/rubio/player.rb
@@ -4,7 +4,7 @@ module Rubio
   class Player
     attr_accessor :backend, :pid, :thr, :status, :history
 
-    def initialize(backend = 'cvlc')
+    def initialize(backend = OS.mac? ? 'vlc -I rc' : 'cvlc')
       raise unless backend.is_a?(String)
 
       @backend = backend

--- a/lib/rubio/player.rb
+++ b/lib/rubio/player.rb
@@ -4,7 +4,7 @@ module Rubio
   class Player
     attr_accessor :backend, :pid, :thr, :status, :history
 
-    def initialize(backend = OS.mac? ? 'vlc -I rc' : 'cvlc')
+    def initialize(backend = OS.linux? ? 'cvlc' : 'vlc -I rc')
       raise unless backend.is_a?(String)
 
       @backend = backend
@@ -42,7 +42,7 @@ module Rubio
     def stop
       return unless alive?
 
-      r = Process.kill(:TERM, pid)
+      r = Process.kill(OS.windows? ? :KILL : :TERM, pid)
       @thr = nil
       @pid = nil
       r
@@ -50,7 +50,7 @@ module Rubio
 
     def stop_all
       @history.each do |pid, thr|
-        Process.kill(:TERM, pid) if thr.alive?
+        Process.kill(OS.windows? ? :KILL : :TERM, pid) if thr.alive?
       end
     end
   end

--- a/lib/rubio/radio.rb
+++ b/lib/rubio/radio.rb
@@ -62,6 +62,19 @@ module Rubio
     end
 
     def launch
+      menu('Radio') do
+        menu_item('Stop') do
+          on_clicked do
+            stop_uuid(@station_uuid)
+            @station_uuid = nil
+          end
+        end
+        quit_menu_item {
+          on_clicked do
+            @player.stop_all
+          end
+        }
+      end
       window('Rubio', 400, 200) do
         vertical_box do
           horizontal_box do

--- a/lib/rubio/radio.rb
+++ b/lib/rubio/radio.rb
@@ -9,7 +9,7 @@ module Rubio
     attr_reader :stations, :player
 
     def initialize(backend, debug: false)
-      @stations_all, @table = RadioBrowser.topvote(1000)
+      @stations_all, @table = RadioBrowser.topvote(500)
       @stations = @stations_all.dup
       @station_uuid = nil
       @player = Player.new(backend)


### PR DESCRIPTION
Thank you for your feedback in the previous Pull Request. You were right. The use of a `cvlc` shell script was preventing rubio from stopping radio stations. I fixed it by updating the app to use vlc directly on the Mac instead of cvlc because Mac VLC comes with a `vlc` command instead of `cvlc` (even when installed via Homebrew instead of DMG file). I also added support for Windows.

Changes:
1. Configure backend to `vlc -I rc` instead of `cvlc` on Mac and Windows. This fixed the radio stopping issue on the Mac.
2. Add a Quit menu item to ensure that when quitting the app with the CMD+Q shortcut on the Mac (which forwards to the Quit menu item action), radio playback stops. This fixed an issue whereby if I quit rubio with the CMD+Q shortcut on the Mac, radio continued playing.
3. Add a Radio menu with Stop menu item that stops currently playing radio station. It was mostly added to be able to also add the Quit menu item mentioned above since libui requires that it is nested under a menu, so `Stop` was added to avoid having an empty menu on the Mac (given that quit_menu_item always ends up showing up under the Mac App Menu instead of the menu it was added under in the code).
4. Change top vote radio station count to 500. This seemed to have good performance and be managable enough. So, there wouldn't be a need for pagination with 500 radio stations it seems.
5. Support Windows

Cheers!