### PR TITLE
add country property to radio stations

### DIFF
--- a/lib/rubio/model/radio_browser.rb
+++ b/lib/rubio/model/radio_browser.rb
@@ -19,7 +19,7 @@ module Rubio
         content = URI.parse(base_url + "stations/topvote/#{n}?offset=#{offset}")
         result = []
         JSON[content.read].each_with_index do |s, _i|
-          result << Station.new(s['stationuuid'], s['name'], s['language'], s['url_resolved'])
+          result << Station.new(s['stationuuid'], s['name'], s['language'], s['country'], s['url_resolved'])
         end
         result
       end

--- a/lib/rubio/model/station.rb
+++ b/lib/rubio/model/station.rb
@@ -4,7 +4,7 @@ require_relative 'bookmark'
 
 module Rubio
   module Model
-    Station = Struct.new(:stationuuid, :name, :language, :url, :play, :bookmark) do
+    Station = Struct.new(:stationuuid, :name, :language, :country, :url, :play, :bookmark) do
       attr_reader :playing, :bookmarked
       alias_method :playing?, :playing
       alias_method :bookmarked?, :bookmarked

--- a/lib/rubio/view/radio.rb
+++ b/lib/rubio/view/radio.rb
@@ -212,7 +212,8 @@ module Rubio
 
         table_columns.merge!(
           'name' => :text,
-          'language' => :text
+          'language' => :text,
+          'country' => :text
         )
       end
 


### PR DESCRIPTION
This feature adds an extra column to the stations table. Searching by country could be useful when looking for local news or to practice listening to a language with a specific accent.

![Screenshot 2022-11-13 at 21 56 01](https://user-images.githubusercontent.com/34649378/201566317-d296fec3-bbe1-4c34-b310-657b7561a123.png)

@AndyObtiva , I didn't change the readme file or add updated screenshots! Let me know if it's okay, otherwise I'll do it tomorrow 😃 